### PR TITLE
xargs (moderate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ UPROGS=\
 	$U/_pingpong\
 	$U/_primes\
 	$U/_find\
+	$U/_xargs\
 
 
 

--- a/user/xargs.c
+++ b/user/xargs.c
@@ -1,0 +1,39 @@
+#include "../kernel/types.h"
+#include "../kernel/param.h"
+#include "user.h"
+
+int
+main(int argc, char *argv[])
+{
+	char c, tc[512], *tcp, *p[argc], **tp;	
+	int i;
+
+	if (argc < 2) {
+		fprintf(2, "usage: xargs [command] [paramter]...\n"); 
+		exit(1);
+	}
+
+	if (argc > MAXARG) {
+		fprintf(2, "xargs: too many arguments\n"); 
+		exit(1);
+	}
+	
+	tp = p;
+	for (i = 1; i < argc; i++)
+		*tp++ = argv[i];
+	*tp = tcp = tc;
+
+	while (read(0, &c, 1) && c) {
+		if (c == '\n') {
+			*tcp = '\0';
+			tcp = tc;
+			if (fork() == 0) 
+				exec(argv[1], p);
+		} else {
+			*tcp++ = c;
+		}
+	}
+
+	wait((void *)0);
+	exit(0);
+}


### PR DESCRIPTION
Write a simple version of the UNIX xargs program: its arguments describe a command to run, it reads lines from the standard input, and it runs the command for each line, appending the line to the command's arguments. Your solution should be in the file user/xargs.c.b

The following example illustrates xarg's behavior:
    $ echo hello too | xargs echo bye
    bye hello too
    $

Note that the command here is "echo bye" and the additional arguments are "hello too", making the command "echo bye hello too", which outputs "bye hello too".

Please note that xargs on UNIX makes an optimization where it will feed more than argument to the command at a time. We don't expect you to make this optimization. To make xargs on UNIX behave the way we want it to for this lab, please run it with the -n option set to 1. For instance

    $ (echo 1 ; echo 2) | xargs -n 1 echo
    1
    2
    $

Some hints:

Use fork and exec to invoke the command on each line of input. Use wait in the parent to wait for the child to complete the command. To read individual lines of input, read a character at a time until a newline ('\n') appears.
kernel/param.h declares MAXARG, which may be useful if you need to declare an argv array.

Add the program to UPROGS in Makefile.

Changes to the file system persist across runs of qemu; to get a clean file system run make clean and then make qemu.

xargs, find, and grep combine well:

  $ find . b | xargs grep hello

will run "grep hello" on each file named b in the directories below ".". To test your solution for xargs, run the shell script xargstest.sh. Your solution is correct if it produces the following output:

  $ make qemu
  ...
  init: starting sh
  $ sh < xargstest.sh
  $ $ $ $ $ $ hello
  hello
  hello
  $ $

You may have to go back and fix bugs in your find program. The output has many $ because the xv6 shell doesn't realize it is processing commands from a file instead of from the console, and prints a $ for each command in the file.